### PR TITLE
fix: group 예외처리(#3)

### DIFF
--- a/matching/main.py
+++ b/matching/main.py
@@ -1,7 +1,7 @@
 import random
 from typing import Dict, List, FrozenSet
 from db import SessionLocal
-from db_models import Manittos, UserGroups
+from db_models import Manittos, UserGroups 
 from matcher import ORToolsMatcher
 from get_week_index import GetWeekIndex
 from datetime import datetime
@@ -22,8 +22,10 @@ user_group_map = {
 }
 
 # group_id -> user_id 목록 매핑
-group_users = {}
-for uid, gid in user_group_map.items():
+group_users: Dict[int, List[int]] = {}
+for record in session.query(UserGroups.user_id, UserGroups.group_id):
+    uid = record.user_id
+    gid = record.group_id
     group_users.setdefault(gid, []).append(uid)
 
 # 과거 매칭 정보 로드
@@ -50,6 +52,9 @@ for group_id, users in group_users.items():
     # 매칭 실행
     start_user = users[0]  # 시작 노드를 첫 번째 사용자로 고정
     matcher = ORToolsMatcher(previous_matches, current_week)
+    # users_ids = [u.id for u in session.query(Users.id).all()]
+    # print(f"user_ids 개수:  {len(users_ids)}")
+
     route, total_cost = matcher.solve_route(users, start_user)
 
     if not route:

--- a/matching/matcher.py
+++ b/matching/matcher.py
@@ -18,6 +18,9 @@ class ORToolsMatcher:
         start_node: int, # 시작할 사용자 ID
         time_limit: int = 5 # 탐색 시간 제한
     ) -> Tuple[List[Tuple[int, int]], int]:
+        if len(user_ids) <=2:
+            print("매칭을 진행할 수 없습니다")
+            return [], 0
        
 
         # 비용 행렬 생성


### PR DESCRIPTION
# Google PATH_CHEAPESH_ARC 방식 활용 순환 매칭 적용

- 시작 노드 첫번째 사용자 고정
- 그룹 내 마니또-마니띠 모두 매칭
- 그룹 내 인원이 2명인 경우 예외처리

## 수학적 정의

`PATH_CHEAPEST_ARC`는 **외판원 순회 문제(TSP)**의 초기 해를 구하는 **탐욕적 알고리즘**으로 정의되며, 다음 수식으로 표현됩니다.

### 알고리즘 정의

- **주어진 집합**: $V = \{v_1, v_2, \dots, v_n\}$ (참가자 집합)
- **비용 행렬**: $C = [c_{ij}]$, $c_{ij}$는 $v_i$에서 $v_j$로 가는 비용 (작을수록 궁합이 좋음)

### 알고리즘 흐름

1. 시작 노드 $v_s$ 선택
2. 현재 노드 $v_{\text{cur}}$에서 아직 방문하지 않은 노드 중 최소 비용 $c_{ij}$를 가지는 $v_j$ 선택:
   $$
   v_{\text{next}} = \arg\min_{j \in V_{\text{unvisited}}} c_{v_{\text{cur}}, j}
   $$
3. $v_{\text{cur}} \to v_{\text{next}}$로 이동하고, $v_{\text{next}}$를 방문 처리
4. 모든 노드를 방문할 때까지 반복
5. 마지막 노드에서 시작 노드로 돌아가는 경로 추가하여 **순환 경로** 구성